### PR TITLE
feat(admin): Add backup management interface with backup/delete opera…

### DIFF
--- a/django_postgres_backup/admin.py
+++ b/django_postgres_backup/admin.py
@@ -1,0 +1,126 @@
+from django.contrib import admin
+from django.http import FileResponse, HttpResponse, HttpResponseRedirect
+from django.urls import path
+from django.utils.html import format_html
+from django.db import models
+import os
+import glob
+from datetime import datetime
+from django_postgres_backup.settings import POSTGRES_BACKUP_DIR, DATABASE_DEFAULT
+from django_postgres_backup.common import backup_and_cleanup_database
+from django.contrib import messages
+from django_postgres_backup.settings import POSTGRES_BACKUP_GENERATIONS
+
+
+class DummyBackupFile(models.Model):
+    """Dummy model for the changelist view."""
+    class Meta:
+        managed = False
+        verbose_name_plural = "Database Backups"
+        app_label = 'django_postgres_backup'
+
+    def __str__(self):
+        return "Database Backups"
+
+
+class BackupFileAdmin(admin.ModelAdmin):
+    def get_queryset(self, request):
+        return DummyBackupFile.objects.none()
+
+    def changelist_view(self, request, extra_context=None):
+        if '_backup' in request.POST:
+            try:
+                backup_and_cleanup_database(
+                    database_format='t',
+                    database_name=DATABASE_DEFAULT['NAME'],
+                    name=DATABASE_DEFAULT['NAME'],
+                    generation=POSTGRES_BACKUP_GENERATIONS,
+                    username=DATABASE_DEFAULT['USER'],
+                    path=POSTGRES_BACKUP_DIR,
+                )
+                self.message_user(request, "Backup created successfully!", messages.SUCCESS)
+            except Exception as e:
+                self.message_user(request, f"Error creating backup: {str(e)}", messages.ERROR)
+            return HttpResponseRedirect(".")
+
+        backup_dir = POSTGRES_BACKUP_DIR
+        backup_files = glob.glob(os.path.join(backup_dir, '*.sql.bz2'))
+        backups = []
+        for filepath in sorted(backup_files, reverse=True):
+            filename = os.path.basename(filepath)
+            try:
+                date_str = filename.split('-', 1)[1].rsplit('.', 2)[0]
+                date = datetime.strptime(date_str, '%Y-%m-%d_%H-%M')
+                formatted_date = date.strftime('%Y-%m-%d %H:%M')
+            except (ValueError, IndexError):
+                formatted_date = "Unknown"
+
+            size = os.path.getsize(filepath)
+            size_mb = size / (1024 * 1024)
+
+            download_url = f'download/{os.path.basename(filepath)}/'
+            download_link = format_html('<a href="{}">Download</a>', download_url)
+            delete_url = f'delete/{os.path.basename(filepath)}/'
+            delete_link = format_html(
+                '<a href="{}" onclick="return confirm(\'Are you sure you want to delete this backup?\');" style="color: #ba2121;">Delete</a>', delete_url)
+
+            backups.append({
+                'filename': filename,
+                'date': formatted_date,
+                'size': f'{size_mb:.2f} MB',
+                'download': format_html('{} | {}', download_link, delete_link),
+            })
+
+        extra_context = extra_context or {}
+        extra_context['backups'] = backups
+        extra_context['title'] = 'Database Backups'
+
+        template_response = super().changelist_view(request, extra_context)
+        template_response.template_name = 'admin/backup_file_changelist.html'
+        return template_response
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return True
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path('download/<path:filepath>/', self.download_backup, name='download_backup'),
+            path('delete/<path:filepath>/', self.delete_backup, name='delete_backup'),
+        ]
+        return custom_urls + urls
+
+    def download_backup(self, request, filepath):
+        backup_dir = POSTGRES_BACKUP_DIR
+        file_path = os.path.join(backup_dir, filepath)
+
+        if os.path.exists(file_path) and os.path.isfile(file_path):
+            response = FileResponse(open(file_path, 'rb'))
+            response['Content-Type'] = 'application/x-bzip2'
+            response['Content-Disposition'] = f'attachment; filename="{os.path.basename(file_path)}"'
+            return response
+        return HttpResponse('File not found', status=404)
+
+    def delete_backup(self, request, filepath):
+        backup_dir = POSTGRES_BACKUP_DIR
+        file_path = os.path.join(backup_dir, filepath)
+
+        try:
+            if os.path.exists(file_path) and os.path.isfile(file_path):
+                os.remove(file_path)
+                self.message_user(request, f"Backup {filepath} deleted successfully!", messages.SUCCESS)
+            else:
+                self.message_user(request, f"Backup file {filepath} not found.", messages.WARNING)
+        except Exception as e:
+            self.message_user(request, f"Error deleting backup: {str(e)}", messages.ERROR)
+
+        return HttpResponseRedirect("../../")
+
+
+admin.site.register(DummyBackupFile, BackupFileAdmin)

--- a/django_postgres_backup/settings.py
+++ b/django_postgres_backup/settings.py
@@ -33,6 +33,7 @@ if DATABASE_PASSWORD is None:
     raise ValueError("'PASSWORD' must be defined in 'default'")
 
 DEFAULT_POSTGRES_BACKUP_GENERATIONS = 3
+DEFAULT_POSTGRES_BACKUP_DIR = BASE_DIR / "backup"
 POSTGRES_BACKUP_GENERATIONS = (
     getattr(settings, "POSTGRES_BACKUP_GENERATIONS", None)
     if getattr(settings, "POSTGRES_BACKUP_GENERATIONS", None)
@@ -40,3 +41,8 @@ POSTGRES_BACKUP_GENERATIONS = (
 )
 if POSTGRES_BACKUP_GENERATIONS < 1:
     raise ValueError("'POSTGRES_BACKUP_GENERATIONS' must be defined at lest 1.")
+POSTGRES_BACKUP_DIR = (
+    getattr(settings, "POSTGRES_BACKUP_DIR", None)
+    if getattr(settings, "POSTGRES_BACKUP_DIR", None)
+    else DEFAULT_POSTGRES_BACKUP_DIR
+)

--- a/django_postgres_backup/templates/admin/backup_file_changelist.html
+++ b/django_postgres_backup/templates/admin/backup_file_changelist.html
@@ -1,0 +1,49 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<div id="content-main">
+    <div class="module filtered" id="changelist">
+        <div style="padding: 10px 0;">
+            <form method="post">
+                {% csrf_token %}
+                <input type="submit" name="_backup" value="Backup Now" class="default" style="float: right; margin-right: 10px;"/>
+            </form>
+        </div>
+        <div class="results">
+            <table id="result_list">
+                <thead>
+                    <tr>
+                        <th scope="col">
+                            <div class="text">{% trans 'Filename' %}</div>
+                        </th>
+                        <th scope="col">
+                            <div class="text">{% trans 'Date' %}</div>
+                        </th>
+                        <th scope="col">
+                            <div class="text">{% trans 'Size' %}</div>
+                        </th>
+                        <th scope="col">
+                            <div class="text">{% trans 'Actions' %}</div>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for backup in backups %}
+                    <tr class="{% cycle 'row1' 'row2' %}">
+                        <td>{{ backup.filename }}</td>
+                        <td>{{ backup.date }}</td>
+                        <td>{{ backup.size }}</td>
+                        <td>{{ backup.download|safe }}</td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="4">{% trans 'No backup files found.' %}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
…tions

Add Django admin interface for managing database backups with the following features:
- Display list of existing backups with dates and sizes
- "Backup Now" button for immediate database backup
- Download functionality for backup files
- Delete functionality with confirmation dialog
- Success/error feedback messages for all operations

Technical changes:
- Add DummyBackupFile model for admin integration
- Custom admin view with file system operations
- Template with Bootstrap-styled backup list
- Proper error handling and user feedback
- Integration with project's backup settings

This provides a user-friendly interface for database backup management directly in the Django admin panel.